### PR TITLE
Support GHC 9.6.

### DIFF
--- a/cloud-pubsub.cabal
+++ b/cloud-pubsub.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.36.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -56,6 +56,7 @@ library
       DuplicateRecordFields
       GeneralizedNewtypeDeriving
       LambdaCase
+      OverloadedRecordDot
       OverloadedStrings
   ghc-options: -Wall -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints -Wno-deprecations
   build-depends:
@@ -113,6 +114,7 @@ test-suite cloud-pubsub-test
       DuplicateRecordFields
       GeneralizedNewtypeDeriving
       LambdaCase
+      OverloadedRecordDot
       OverloadedStrings
   ghc-options: -Wall -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints -Wno-deprecations -threaded -rtsopts -with-rtsopts=-N
   build-depends:

--- a/package.yaml
+++ b/package.yaml
@@ -22,6 +22,7 @@ default-extensions:
   - DuplicateRecordFields
   - GeneralizedNewtypeDeriving
   - LambdaCase
+  - OverloadedRecordDot
   - OverloadedStrings
 
 ghc-options:

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-18.10
+resolver: lts-22.7
 packages:
   - .
 extra-deps:

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -3,10 +3,10 @@
 # For more information, please see the documentation at:
 #   https://docs.haskellstack.org/en/stable/lock_files
 
-snapshots:
-- original: lts-18.10
-  completed:
-    sha256: 88b4f81e162ba3adc230a9fcccc4d19ac116377656bab56c7382ca88598b257a
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/10.yaml
-    size: 587546
 packages: []
+snapshots:
+- completed:
+    sha256: 7b975b104cb3dbf0c297dfd01f936a4d2ee523241dd0b1ae960522b833fe3027
+    size: 714096
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/22/7.yaml
+  original: lts-22.7

--- a/test/Cloud/PubSub/SnapshotSpec.hs
+++ b/test/Cloud/PubSub/SnapshotSpec.hs
@@ -4,6 +4,8 @@ import           Cloud.PubSub.Core.Types        ( UpdateMask(..) )
 import qualified Cloud.PubSub.Http.Types       as HttpT
 import qualified Cloud.PubSub.Snapshot         as Snapshot
 import qualified Cloud.PubSub.Snapshot.Types   as SnapshotT
+import qualified Cloud.PubSub.Snapshot.Types   as SnapshotT.Snapshot
+                                                ( Snapshot(..) )
 import           Cloud.PubSub.TestHelpers       ( TestEnv
                                                 , mkTestPubSubEnv
                                                 , runTest
@@ -38,8 +40,8 @@ snapshotUpdateTest =
         let
           snapshotPatch = SnapshotT.SnapshotPatch
             { snapshot   = initialSnap
-              { SnapshotT.labels = Just
-                                     $ HM.fromList [("patched", "successful")]
+              { SnapshotT.Snapshot.labels =
+                  Just $ HM.fromList [("patched", "successful")]
               }
             , updateMask = UpdateMask "labels"
             }

--- a/test/Cloud/PubSub/SubscriptionSpec.hs
+++ b/test/Cloud/PubSub/SubscriptionSpec.hs
@@ -5,6 +5,9 @@ import qualified Cloud.PubSub.Http.Types       as HttpT
 import qualified Cloud.PubSub.Subscription     as Subscription
 import qualified Cloud.PubSub.Subscription.Types
                                                as SubscriptionT
+import qualified Cloud.PubSub.Subscription.Types
+                                               as SubscriptionT.Subscription
+                                                ( Subscription(..) )
 import           Cloud.PubSub.TestHelpers       ( TestEnv
                                                 , mkTestPubSubEnv
                                                 , runTest
@@ -30,11 +33,11 @@ testMessage = Topic.PublishPubsubMessage { ppmOrderingKey = Just "constant-key"
 resetPublishConfigAttributes
   :: SubscriptionT.Subscription -> SubscriptionT.Subscription
 resetPublishConfigAttributes sub = sub
-  { SubscriptionT.pushConfig = Just pushConfig
+  { SubscriptionT.Subscription.pushConfig = Just pushConfig
   }
  where
   pushConfig =
-    (fromJust $ SubscriptionT.pushConfig (sub :: SubscriptionT.Subscription))
+    (fromJust sub.pushConfig)
       { SubscriptionT.attributes = Nothing
       }
 
@@ -57,8 +60,8 @@ subscriptionUpdateTest =
     let
       subPatch = SubscriptionT.SubscriptionPatch
         { subscription = initialSub
-          { SubscriptionT.labels = Just
-                                     $ HM.fromList [("patched", "successful")]
+          { SubscriptionT.Subscription.labels =
+              Just $ HM.fromList [("patched", "successful")]
           }
         , updateMask   = Core.UpdateMask "labels"
         }

--- a/test/Cloud/PubSub/TopicSpec.hs
+++ b/test/Cloud/PubSub/TopicSpec.hs
@@ -10,6 +10,8 @@ import           Cloud.PubSub.TestHelpers       ( TestEnv
                                                 )
 import qualified Cloud.PubSub.Topic            as Topic
 import qualified Cloud.PubSub.Topic.Types      as TopicT
+import qualified Cloud.PubSub.Topic.Types      as TopicT.Topic
+                                                ( Topic(..) )
 import           Control.Monad.IO.Class         ( liftIO )
 import           Data.Functor                   ( void )
 import qualified Data.HashMap.Strict           as HM
@@ -29,7 +31,7 @@ topicUpdateTest = runTestIfNotEmulator $ withTestTopic topic $ do
   initialTopic <- Topic.get topic
   let topicPatch = TopicT.TopicPatch
         { topic      = initialTopic
-          { TopicT.labels = Just $ HM.fromList [("patched", "successful")]
+          { TopicT.Topic.labels = Just $ HM.fromList [("patched", "successful")]
           }
         , updateMask = Core.UpdateMask "labels"
         }


### PR DESCRIPTION
The nix-shell breaks here, since it's using a snapshot too old to have this LTS. I don't know how to fix it; when I put

    url = "https://github.com/input-output-hk/haskell.nix/archive/5559d7bc4ad00bada614d1c4473d5cf38eb905f2.tar.gz";
    sha256 = "1a9cbaq1h5wq9awijq98zkwaalbvqjql98zms2zgjbhxl3kg524m";

taken from excelsior's current master, I get another error:

    error: function 'anonymous lambda' called with unexpected argument 'fetchSubmodules'