### PR TITLE
Add an implicit auth method

### DIFF
--- a/src/Cloud/PubSub.hs
+++ b/src/Cloud/PubSub.hs
@@ -34,6 +34,7 @@ data CloudConfig = CloudConfig
   deriving (Show, Eq)
 
 data PubSubTarget = EmulatorTarget HostAndPort
+                  | ImplicitTarget
                   | CloudServiceTarget CloudConfig
                     deriving (Show,Eq)
 
@@ -43,6 +44,8 @@ mkClientResources projectId target = do
     EmulatorTarget hostAndPort -> do
       let hostAndPortUrl = "http://" <> unwrapHostAndPort hostAndPort
       return (hostAndPortUrl, Emulator)
+    ImplictTarget ->
+      return ("https://pubsub.googleapis.com", Implicit)
     CloudServiceTarget (CloudConfig threshold (ServiceAccountFile saFile)) ->
       do
         resources <-

--- a/src/Cloud/PubSub/Auth/Token.hs
+++ b/src/Cloud/PubSub/Auth/Token.hs
@@ -51,6 +51,7 @@ getToken = do
   clientResources <- HttpT.askClientResources
   case HttpT.crTargetResorces clientResources of
     HttpT.Emulator             -> return Nothing
+    HttpT.Implicit             -> return Nothing
     HttpT.Cloud cloudResources -> Just <$> do
       let manager   = HttpT.crManager clientResources
           tokenMVar = HttpT.ctrCachedTokenMVar cloudResources

--- a/src/Cloud/PubSub/Http/Types.hs
+++ b/src/Cloud/PubSub/Http/Types.hs
@@ -50,6 +50,7 @@ data CloudTargetResources = CloudTargetResources
   }
 
 data TargetResources = Emulator
+                     | Implicit
                      | Cloud CloudTargetResources
 
 data ClientResources = ClientResources


### PR DESCRIPTION
This can't work, right? @tanakadesilva 

Apparently the service account file stuff is deprecated. Andrew says the modern way is to just not pass any auth info. Maybe that works with the official client libraries, but I don't really see how that could work with the HTTP API.