### PR TITLE
fix: pin third-party actions to SHA to prevent supply chain attacks

### DIFF
--- a/.github/workflows/nix-emulator.yaml
+++ b/.github/workflows/nix-emulator.yaml
@@ -12,13 +12,13 @@ jobs:
       - name: Start PubSub Emulator
         run: |
           docker compose up --build -d pubsub-emulator
-      - uses: cachix/install-nix-action@v30
+      - uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 # v30
         with:
           nix_path: nixpkgs=channel:nixos-unstable
           extra_nix_config: |
             trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
             substituters = https://hydra.iohk.io https://cache.nixos.org/
-      - uses: cachix/cachix-action@v15
+      - uses: cachix/cachix-action@ad2ddac53f961de1989924296a1f236fcfbaa4fc # v15
         with:
           name: proda-ai-cloud-pubsub
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"

--- a/.github/workflows/stack-cloud.yaml
+++ b/.github/workflows/stack-cloud.yaml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: haskell-actions/setup@v2
+      - uses: haskell-actions/setup@f9150cb1d140e9a9271700670baa38991e6fa25c # v2.10.3
         with:
           enable-stack: true
           stack-no-global: true


### PR DESCRIPTION
## Summary

Pins cachix and haskell-actions to immutable commit SHAs. Mutable semver tags are vulnerable to supply chain attacks via tag hijacking (ref: GHSA-69fq-xp46-6x23).